### PR TITLE
Added edge cases of the single chain swap

### DIFF
--- a/test/specs/mainnet/swap/Regression_SingleChainSwap.spec.js
+++ b/test/specs/mainnet/swap/Regression_SingleChainSwap.spec.js
@@ -479,7 +479,7 @@ describe("The regression suite for the single chain swap on the MainNet", () => 
   });
 
   // SWAP ON XDAI NETWORK WITHOUT ESTIMATION OF THE BATCH
-  it.only("Setup the SDK for xDai network and perform the single chain swap action without estimation of the batch.", async () => {
+  it("Setup the SDK for xDai network and perform the single chain swap action without estimation of the batch.", async () => {
     let transactionDetails;
     let TransactionData_count = 0;
 
@@ -535,6 +535,357 @@ describe("The regression suite for the single chain swap on the MainNet", () => 
       console.log(
         e,
         "Status of the batch is not submitted, Because Estimation of batch is remaining."
+      );
+    }
+  });
+
+  // SWAP ON XDAI NETWORK FROM ERC20 TOKEN TO ERC20 TOKEN WITH EXCEED TOKEN BALANCE
+  it("Setup the SDK for xDai network and perform the single chain swap action from ERC20 token to ERC20 Token with exceed token balance.", async () => {
+    // Initialize the SDK and define network
+    sdkMainNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.MainNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkMainNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkMainNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    const offers = await sdkMainNet.getExchangeOffers({
+      fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+      toTokenAddress: "0x4ECaBa5870353805a9F068101A40E0f32ed605C6", // USDT Token
+      // toTokenAddress: ethers.constants.AddressZero,
+      fromAmount: ethers.utils.parseUnits("100000000", 6),
+    });
+
+    // Estimating the batch
+    try {
+      await sdkMainNet.estimateGatewayBatch();
+
+      assert.isFalse(
+        "The Estimation is performed even if exceed the token account."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Estimation is not happened due to exceed token account."
+      );
+    }
+  });
+
+  // SWAP ON XDAI NETWORK FROM ERC20 TOKEN TO NATIVE TOKEN WITH EXCEED TOKEN BALANCE
+  it("Setup the SDK for xDai network and perform the single chain swap action from ERC20 token to native token with exceed token balance.", async () => {
+    // Initialize the SDK and define network
+    sdkMainNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.MainNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkMainNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkMainNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    const offers = await sdkMainNet.getExchangeOffers({
+      fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+      // fromTokenAddress: ethers.constants.AddressZero,
+      // toTokenAddress: "0x4ECaBa5870353805a9F068101A40E0f32ed605C6", // USDT Token
+      toTokenAddress: ethers.constants.AddressZero,
+      fromAmount: ethers.utils.parseUnits("100000000", 6),
+    });
+
+    // Estimating the batch
+    try {
+      await sdkMainNet.estimateGatewayBatch();
+
+      assert.isFalse(
+        "The Estimation is performed even if exceed the token account."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Estimation is not happened due to exceed token account."
+      );
+    }
+  });
+
+  // SWAP ON XDAI NETWORK FROM ERC20 TOKEN TO THE SAME ERC20 TOKEN
+  it("Setup the SDK for xDai network and perform the single chain swap action from ERC20 token to the same ERC20 token.", async () => {
+    // Initialize the SDK and define network
+    sdkMainNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.MainNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkMainNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkMainNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    try {
+      await sdkMainNet.getExchangeOffers({
+        fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+        // fromTokenAddress: ethers.constants.AddressZero,
+        toTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+        // toTokenAddress: ethers.constants.AddressZero,
+        fromAmount: ethers.utils.parseUnits("0.0001", 6),
+      });
+      assert.isFalse(
+        "The Swap is performed, Even if the ERC20 Token addresses are equal."
+      );
+    } catch (e) {
+      console.log(e, "The ERC20 Token addresses are not equal.");
+    }
+  });
+
+  // SWAP ON XDAI NETWORK WITHOUT toTokenAddress VALUE WHILE GET THE EXCHANGE OFFERS
+  it("Setup the SDK for xDai network and perform the single chain swap action without toTokenAddress value while get the exchange offers.", async () => {
+    // Initialize the SDK and define network
+    sdkMainNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.MainNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkMainNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkMainNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    try {
+      await sdkMainNet.getExchangeOffers({
+        fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+        fromAmount: ethers.utils.parseUnits("0.0001", 6),
+      });
+      assert.isFalse(
+        "The Swap is performed, Even if the To Token Address is not added in the Get Exchange Offers."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Get Exchange Offers is not performed due to The To Token Address is not added."
+      );
+    }
+  });
+
+  // SWAP ON XDAI NETWORK WITHOUT fromTokenAddress VALUE WHILE GET THE EXCHANGE OFFERS
+  it("Setup the SDK for xDai network and perform the single chain swap action without fromTokenAddress value while get the exchange offers.", async () => {
+    // Initialize the SDK and define network
+    sdkMainNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.MainNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkMainNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkMainNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    try {
+      await sdkMainNet.getExchangeOffers({
+        toTokenAddress: "0x4ECaBa5870353805a9F068101A40E0f32ed605C6", // USDT Token
+        fromAmount: ethers.utils.parseUnits("0.0001", 6),
+      });
+      assert.isFalse(
+        "The Swap is performed, Even if the From Token Address is not added in the Get Exchange Offers."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Get Exchange Offers is not performed due to The From Token Address is not added."
+      );
+    }
+  });
+
+  // SWAP ON XDAI NETWORK WITHOUT fromAmount VALUE WHILE GET THE EXCHANGE OFFERS
+  it("Setup the SDK for xDai network and perform the single chain swap action without fromAmount value while get the exchange offers.", async () => {
+    // Initialize the SDK and define network
+    sdkMainNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.MainNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkMainNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkMainNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    try {
+      await sdkMainNet.getExchangeOffers({
+        fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+        toTokenAddress: "0x4ECaBa5870353805a9F068101A40E0f32ed605C6", // USDT Token
+      });
+      assert.isFalse(
+        "The Swap is performed, Even if the From Amount is not added in the Get Exchange Offers."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Get Exchange Offers is not performed due to The From Amount is not added."
+      );
+    }
+  });
+
+  // SWAP ON XDAI NETWORK WITH INVALID toTokenAddress VALUE WHILE GET THE EXCHANGE OFFERS
+  it("Setup the SDK for xDai network and perform the single chain swap action with invalid toTokenAddress value while get the exchange offers.", async () => {
+    // Initialize the SDK and define network
+    sdkMainNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.MainNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkMainNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkMainNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    try {
+      await sdkMainNet.getExchangeOffers({
+        fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+        toTokenAddress: "0x4ECaBa5870353805a9F068101A40E0f32ed605CC", // USDT Token
+        fromAmount: ethers.utils.parseUnits("0.0001", 6),
+      });
+      assert.isFalse(
+        "The Swap is performed, Even if the To Token Address is not added in the Get Exchange Offers."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Get Exchange Offers is not performed due to The To Token Address is not added."
+      );
+    }
+  });
+
+  // SWAP ON XDAI NETWORK WITH INVALID fromTokenAddress VALUE WHILE GET THE EXCHANGE OFFERS
+  it("Setup the SDK for xDai network and perform the single chain swap action with invalid fromTokenAddress value while get the exchange offers.", async () => {
+    // Initialize the SDK and define network
+    sdkMainNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.MainNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkMainNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkMainNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    try {
+      await sdkMainNet.getExchangeOffers({
+        fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A88", // USDC Token
+        toTokenAddress: "0x4ECaBa5870353805a9F068101A40E0f32ed605C6", // USDT Token
+        fromAmount: ethers.utils.parseUnits("0.0001", 6),
+      });
+      assert.isFalse(
+        "The Swap is performed, Even if the From Token Address is not added in the Get Exchange Offers."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Get Exchange Offers is not performed due to The From Token Address is not added."
       );
     }
   });

--- a/test/specs/practise/PracticeCode.spec.js
+++ b/test/specs/practise/PracticeCode.spec.js
@@ -6,118 +6,110 @@ import { EnvNames, NetworkNames, Sdk } from "etherspot";
 import { BigNumber } from "ethers";
 import Helper from "../../utils/Helper.js";
 
-let sdkMainNet;
+let sdkMainNet1;
 let smartWalletAddress;
 let hashAddressBig;
 let transactionState;
 
-let networkname = [Xdai, Mumbai];
-// let networkname = {
-//   xdai: Xdai,
-//   mumbai: Mumbai,
-// };
-
 describe("Get the transaction history on the MainNet", () => {
   // SEND NATIVE TOKEN FOR XDAI
   it("Setup the SDK for Xdai network and perform the send native asset action", async () => {
-    for (let i = 0; i < networkname.length; i++) {
-      // initialize the sdk
-      sdkMainNet = new Sdk(process.env.PRIVATE_KEY, {
-        env: EnvNames.MainNets,
-        networkName: NetworkNames.networkname[i],
+    // initialize the sdk
+    sdkMainNet1 = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.MainNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    expect(sdkMainNet.state.accountAddress).to.equal(
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f"
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkMainNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    expect(smartWalletAddress).to.equal(
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe"
+    );
+
+    // Adding transaction to a batch
+    const addTransactionToBatchOutput =
+      await sdkMainNet.batchExecuteAccountTransaction({
+        to: "0x0fd7508903376dab743a02743cadfdc2d92fceb8",
+        value: "1000000000000",
       });
+    console.log("Batch Reponse: ", addTransactionToBatchOutput);
 
-      expect(sdkMainNet.state.accountAddress).to.equal(
-        "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f"
-      );
+    // Estimating the batch
+    const estimationResponse = await sdkMainNet.estimateGatewayBatch();
+    console.log("Gas estimated at:", estimationResponse);
 
-      // Compute the smart wallet address
-      const smartWalletOutput = await sdkMainNet.computeContractAccount();
-      smartWalletAddress = smartWalletOutput.address;
-      console.log("Smart wallet address: ", smartWalletAddress);
+    // Submitting the batch
+    const submissionResponse = await sdkMainNet.submitGatewayBatch({
+      guarded: false,
+    });
+    console.log("Status of the batch submition: ", submissionResponse);
+    hashAddressBig = BigNumber.from(submissionResponse.hash)._hex;
+    console.log("BIG HASH ADDRESS: ", hashAddressBig);
 
-      expect(smartWalletAddress).to.equal(
-        "0x666E17ad27fB620D7519477f3b33d809775d65Fe"
-      );
-
-      // Adding transaction to a batch
-      const addTransactionToBatchOutput =
-        await sdkMainNet.batchExecuteAccountTransaction({
-          to: "0x0fd7508903376dab743a02743cadfdc2d92fceb8",
-          value: "1000000000000",
-        });
-      console.log("Batch Reponse: ", addTransactionToBatchOutput);
-
-      // Estimating the batch
-      const estimationResponse = await sdkMainNet.estimateGatewayBatch();
-      console.log("Gas estimated at:", estimationResponse);
-
-      // Submitting the batch
-      const submissionResponse = await sdkMainNet.submitGatewayBatch({
-        guarded: false,
-      });
-      console.log("Status of the batch submition: ", submissionResponse);
-      hashAddressBig = BigNumber.from(submissionResponse.hash)._hex;
-      console.log("BIG HASH ADDRESS: ", hashAddressBig);
-
-      // get the submitted batch and wait till the status become sent
-      do {
-        const output = await sdkMainNet.getGatewaySubmittedBatch({
-          hash: hashAddressBig,
-        });
-        transactionState = output.state;
-
-        Helper.wait(2000);
-      } while (!(transactionState == "Sent"));
-
-      // get submmited batch with sent status
+    // get the submitted batch and wait till the status become sent
+    do {
       const output = await sdkMainNet.getGatewaySubmittedBatch({
         hash: hashAddressBig,
       });
-      console.log("Gateway Submitted Batch after sending: ", output);
-      console.log(
-        "Transaction State of Fetched Batch after sending: ",
-        output.transaction.state
-      );
-      console.log(
-        "Transaction Hash of Fetched Batch after sending: ",
-        output.transaction.hash
-      );
+      transactionState = output.state;
 
-      // Fetching a single transaction
-      const singleTransaction = await sdkMainNet.getTransaction({
-        hash: output.transaction.hash, // Add your transaction hash
-      });
-      console.log("Single Transaction: ", singleTransaction);
-      console.log(
-        "Single Transaction Hash of the blockchain: ",
-        singleTransaction.hash
-      );
-      console.log(
-        "Final Status of the single transaction on xDai network: ",
-        singleTransaction.status
-      );
+      Helper.wait(2000);
+    } while (!(transactionState == "Sent"));
 
-      expect(singleTransaction.status).to.equal("Completed");
+    // get submmited batch with sent status
+    const output = await sdkMainNet.getGatewaySubmittedBatch({
+      hash: hashAddressBig,
+    });
+    console.log("Gateway Submitted Batch after sending: ", output);
+    console.log(
+      "Transaction State of Fetched Batch after sending: ",
+      output.transaction.state
+    );
+    console.log(
+      "Transaction Hash of Fetched Batch after sending: ",
+      output.transaction.hash
+    );
 
-      // Fetching historical transactions
-      const transactions = await sdkMainNet.getTransactions();
-      //console.log("Transactions: ", transactions);
-      console.log(
-        "Respective Transaction Hash from the transactions list of the blockchain: ",
-        transactions.items[0].hash
-      );
-      console.log(
-        "Respective Transaction Status from the transactions list of the blockchain: ",
-        transactions.items[0].status
-      );
+    // Fetching a single transaction
+    const singleTransaction = await sdkMainNet.getTransaction({
+      hash: output.transaction.hash, // Add your transaction hash
+    });
+    console.log("Single Transaction: ", singleTransaction);
+    console.log(
+      "Single Transaction Hash of the blockchain: ",
+      singleTransaction.hash
+    );
+    console.log(
+      "Final Status of the single transaction on xDai network: ",
+      singleTransaction.status
+    );
 
-      expect(transactions.items[0].status).to.equal("Completed");
+    expect(singleTransaction.status).to.equal("Completed");
 
-      // VALIDATE THE TRANSACTION HASH OF THE SINGLE TRANSACTION AND FROM THE TRANSACTION LIST
-      expect(output.transaction.hash).to.equal(singleTransaction.hash); // validate hash of sent batch and single transaction is displayed same
-      expect(output.transaction.hash).to.equal(transactions.items[0].hash); // validate hash of sent batch and from transaction list is displayed same
-      expect(singleTransaction.hash).to.equal(transactions.items[0].hash); // validate hash of single transaction and from transaction list is displayed same
-    }
+    // Fetching historical transactions
+    const transactions = await sdkMainNet.getTransactions();
+    //console.log("Transactions: ", transactions);
+    console.log(
+      "Respective Transaction Hash from the transactions list of the blockchain: ",
+      transactions.items[0].hash
+    );
+    console.log(
+      "Respective Transaction Status from the transactions list of the blockchain: ",
+      transactions.items[0].status
+    );
+
+    expect(transactions.items[0].status).to.equal("Completed");
+
+    // VALIDATE THE TRANSACTION HASH OF THE SINGLE TRANSACTION AND FROM THE TRANSACTION LIST
+    expect(output.transaction.hash).to.equal(singleTransaction.hash); // validate hash of sent batch and single transaction is displayed same
+    expect(output.transaction.hash).to.equal(transactions.items[0].hash); // validate hash of sent batch and from transaction list is displayed same
+    expect(singleTransaction.hash).to.equal(transactions.items[0].hash); // validate hash of single transaction and from transaction list is displayed same
   });
 });

--- a/test/specs/practise/PracticeCodeNFT.spec.js
+++ b/test/specs/practise/PracticeCodeNFT.spec.js
@@ -1,69 +1,116 @@
 import * as dotenv from "dotenv";
 dotenv.config();
 
-import { expect } from "chai";
-import { EnvNames, NetworkNames, Sdk } from "etherspot";
-import { BigNumber } from "ethers";
-import Helper from "../../utils/Helper.js";
-import abi from "../../data/NFTabi.json" assert { type: "json" };
+import { assert } from "chai";
+import {
+  NETWORK_NAME_TO_CHAIN_ID,
+  CrossChainServiceProvider,
+  EnvNames,
+  NetworkNames,
+  Sdk,
+} from "etherspot";
 import { ethers } from "ethers";
 
 let sdkMainNet;
 let smartWalletAddress;
-let hashAddressBig;
-let transactionState;
 
 describe("The SDK, when sending a NFT Transaction on the MainNet", () => {
+  // export interface ERC20Contract {
+  //   encodeApprove?(spender: string, value: BigNumberish): TransactionRequest;
+  //   callAllowance?(owner: string, spender: string): Promise<string>;
+  // }
+
   // SEND NFT ON XDAI NETWORK
   it.only("Setup the SDK for xDai network and perform the send NFT Transaction action", async () => {
-    // Define NFT details
-    const contract = new ethers.utils.Interface(abi.abi);
-    const to = "0x666E17ad27fB620D7519477f3b33d809775d65Fe"; // from_address
-    const from = "0x49e2a5d77fa210403864f74e6556f17a8fcf70b3"; // to_address
-    const tokenId = "2357194"; // NFTtokenId that needs to be sent
-    const encodedData = contract.encodeFunctionData("transferFrom", [
-      from,
-      to,
-      tokenId,
-    ]);
-
-    // Initialize the SDK and define network
+    // initialize the sdk
     sdkMainNet = new Sdk(process.env.PRIVATE_KEY, {
       env: EnvNames.MainNets,
-      networkName: NetworkNames.Xdai,
+      networkName: NetworkNames.Arbitrum,
     });
+
+    assert.strictEqual(
+      sdkMainNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
 
     // Compute the smart wallet address
     const smartWalletOutput = await sdkMainNet.computeContractAccount();
     smartWalletAddress = smartWalletOutput.address;
     console.log("Smart wallet address: ", smartWalletAddress);
 
-    expect(smartWalletAddress).to.equal(
-      "0x666E17ad27fB620D7519477f3b33d809775d65Fe"
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
     );
 
-    // GET NFT LIST
-    const output = await sdkMainNet.getNftList({
-      account: "0x22c1f6050e56d2876009903609a2cc3fef83b415",
-    });
+    const XdaiUSDC = "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83"; // Xdai - USDC
+    const MaticUSDC = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"; // Matic - USDC
 
-    console.log("Output: ", output);
+    const fromChainId = NETWORK_NAME_TO_CHAIN_ID[NetworkNames.Matic];
+    const toChainId = NETWORK_NAME_TO_CHAIN_ID[NetworkNames.Xdai];
+    const fromTokenAddress = MaticUSDC;
+    const toTokenAddress = XdaiUSDC;
+    const fromAmount = ethers.utils.parseUnits("0.0001", 6); // 10 USDC
 
-    // Adding transaction details to a batch
-    const response = await sdkMainNet.batchExecuteAccountTransaction({
-      to: "0x22c1f6050e56d2876009903609a2cc3fef83b415", // contract_address of the NFT
-      data: encodedData,
-    });
-    console.log("Batch Reponse: ", response);
+    const quoteRequestPayload = {
+      fromChainId: fromChainId,
+      toChainId: toChainId,
+      fromTokenAddress: fromTokenAddress,
+      toTokenAddress: toTokenAddress,
+      fromAmount: fromAmount,
+      serviceProvider: CrossChainServiceProvider.LiFi, // Optional parameter
+    };
+    console.log(quoteRequestPayload);
+    const quotes = await sdkMainNet.getCrossChainQuotes(quoteRequestPayload);
 
-    // Estimating the batch
-    const estimationResponse = await sdkMainNet.estimateGatewayBatch();
-    console.log("Gas estimated at:", estimationResponse);
+    console.log("Quotes", quotes);
 
-    // Submitting the batch
-    const submissionResponse = await sdkMainNet.submitGatewayBatch({
-      guarded: false,
-    });
-    console.log("Status of the batch submition: ", submissionResponse);
+    if (quotes.items.length > 0) {
+      // Select the first quote
+      const quote = quotes.items[0];
+      logger.log("Quote Selected: ", quote);
+
+      const tokenAddres = quote.estimate.data.fromToken.address;
+      const approvalAddress = quote.approvalData.approvalAddress;
+      const amount = quote.approvalData.amount;
+
+      // Build the approval transaction request
+      const abi = getContractAbi(ContractNames.ERC20Token);
+      const erc20Contract =
+        sdkMainNet.registerContract <
+        ERC20Contract >
+        ("erc20Contract", abi, tokenAddres);
+      const approvalTransactionRequest = erc20Contract.encodeApprove(
+        approvalAddress,
+        amount
+      );
+      console.log("Approval transaction request", approvalTransactionRequest);
+      await sdkMainNet.clearGatewayBatch();
+
+      // Batch the approval transaction
+      console.log(
+        "gateway batch approval transaction",
+        await sdkMainNet.batchExecuteAccountTransaction({
+          to: approvalTransactionRequest.to,
+          data: approvalTransactionRequest.data,
+          value: approvalTransactionRequest.value,
+        })
+      );
+
+      // Batch the cross chain transaction
+      const { to, value, data } = quote.transaction;
+      console.log(
+        "gateway batch transfer token transaction",
+        await sdkMainNet.batchExecuteAccountTransaction({
+          to,
+          data: data,
+          value,
+        })
+      );
+    }
+
+    const estimatedGas = await sdkMainNet.estimateGatewayBatch();
   });
 });

--- a/test/specs/testnet/swap/Regression_SingleChainSwap.spec.js
+++ b/test/specs/testnet/swap/Regression_SingleChainSwap.spec.js
@@ -538,4 +538,355 @@ describe("The regression suite for the single chain swap on the TestNet", () => 
       );
     }
   });
+
+  // SWAP ON XDAI NETWORK FROM ERC20 TOKEN TO ERC20 TOKEN WITH EXCEED TOKEN BALANCE
+  it("Setup the SDK for xDai network and perform the single chain swap action from ERC20 token to ERC20 Token with exceed token balance.", async () => {
+    // Initialize the SDK and define network
+    sdkTestNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.TestNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkTestNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkTestNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    const offers = await sdkTestNet.getExchangeOffers({
+      fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+      toTokenAddress: "0x4ECaBa5870353805a9F068101A40E0f32ed605C6", // USDT Token
+      // toTokenAddress: ethers.constants.AddressZero,
+      fromAmount: ethers.utils.parseUnits("100000000", 6),
+    });
+
+    // Estimating the batch
+    try {
+      await sdkTestNet.estimateGatewayBatch();
+
+      assert.isFalse(
+        "The Estimation is performed even if exceed the token account."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Estimation is not happened due to exceed token account."
+      );
+    }
+  });
+
+  // SWAP ON XDAI NETWORK FROM ERC20 TOKEN TO NATIVE TOKEN WITH EXCEED TOKEN BALANCE
+  it("Setup the SDK for xDai network and perform the single chain swap action from ERC20 token to native token with exceed token balance.", async () => {
+    // Initialize the SDK and define network
+    sdkTestNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.TestNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkTestNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkTestNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    const offers = await sdkTestNet.getExchangeOffers({
+      fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+      // fromTokenAddress: ethers.constants.AddressZero,
+      // toTokenAddress: "0x4ECaBa5870353805a9F068101A40E0f32ed605C6", // USDT Token
+      toTokenAddress: ethers.constants.AddressZero,
+      fromAmount: ethers.utils.parseUnits("100000000", 6),
+    });
+
+    // Estimating the batch
+    try {
+      await sdkTestNet.estimateGatewayBatch();
+
+      assert.isFalse(
+        "The Estimation is performed even if exceed the token account."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Estimation is not happened due to exceed token account."
+      );
+    }
+  });
+
+  // SWAP ON XDAI NETWORK FROM ERC20 TOKEN TO THE SAME ERC20 TOKEN
+  it("Setup the SDK for xDai network and perform the single chain swap action from ERC20 token to the same ERC20 token.", async () => {
+    // Initialize the SDK and define network
+    sdkTestNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.TestNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkTestNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkTestNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    try {
+      await sdkTestNet.getExchangeOffers({
+        fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+        // fromTokenAddress: ethers.constants.AddressZero,
+        toTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+        // toTokenAddress: ethers.constants.AddressZero,
+        fromAmount: ethers.utils.parseUnits("0.0001", 6),
+      });
+      assert.isFalse(
+        "The Swap is performed, Even if the ERC20 Token addresses are equal."
+      );
+    } catch (e) {
+      console.log(e, "The ERC20 Token addresses are not equal.");
+    }
+  });
+
+  // SWAP ON XDAI NETWORK WITHOUT toTokenAddress VALUE WHILE GET THE EXCHANGE OFFERS
+  it("Setup the SDK for xDai network and perform the single chain swap action without toTokenAddress value while get the exchange offers.", async () => {
+    // Initialize the SDK and define network
+    sdkTestNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.TestNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkTestNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkTestNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    try {
+      await sdkTestNet.getExchangeOffers({
+        fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+        fromAmount: ethers.utils.parseUnits("0.0001", 6),
+      });
+      assert.isFalse(
+        "The Swap is performed, Even if the To Token Address is not added in the Get Exchange Offers."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Get Exchange Offers is not performed due to The To Token Address is not added."
+      );
+    }
+  });
+
+  // SWAP ON XDAI NETWORK WITHOUT fromTokenAddress VALUE WHILE GET THE EXCHANGE OFFERS
+  it("Setup the SDK for xDai network and perform the single chain swap action without fromTokenAddress value while get the exchange offers.", async () => {
+    // Initialize the SDK and define network
+    sdkTestNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.TestNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkTestNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkTestNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    try {
+      await sdkTestNet.getExchangeOffers({
+        toTokenAddress: "0x4ECaBa5870353805a9F068101A40E0f32ed605C6", // USDT Token
+        fromAmount: ethers.utils.parseUnits("0.0001", 6),
+      });
+      assert.isFalse(
+        "The Swap is performed, Even if the From Token Address is not added in the Get Exchange Offers."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Get Exchange Offers is not performed due to The From Token Address is not added."
+      );
+    }
+  });
+
+  // SWAP ON XDAI NETWORK WITHOUT fromAmount VALUE WHILE GET THE EXCHANGE OFFERS
+  it("Setup the SDK for xDai network and perform the single chain swap action without fromAmount value while get the exchange offers.", async () => {
+    // Initialize the SDK and define network
+    sdkTestNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.TestNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkTestNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkTestNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    try {
+      await sdkTestNet.getExchangeOffers({
+        fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+        toTokenAddress: "0x4ECaBa5870353805a9F068101A40E0f32ed605C6", // USDT Token
+      });
+      assert.isFalse(
+        "The Swap is performed, Even if the From Amount is not added in the Get Exchange Offers."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Get Exchange Offers is not performed due to The From Amount is not added."
+      );
+    }
+  });
+
+  // SWAP ON XDAI NETWORK WITH INVALID toTokenAddress VALUE WHILE GET THE EXCHANGE OFFERS
+  it("Setup the SDK for xDai network and perform the single chain swap action with invalid toTokenAddress value while get the exchange offers.", async () => {
+    // Initialize the SDK and define network
+    sdkTestNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.TestNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkTestNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkTestNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    try {
+      await sdkTestNet.getExchangeOffers({
+        fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC Token
+        toTokenAddress: "0x4ECaBa5870353805a9F068101A40E0f32ed605CC", // USDT Token
+        fromAmount: ethers.utils.parseUnits("0.0001", 6),
+      });
+      assert.isFalse(
+        "The Swap is performed, Even if the To Token Address is not added in the Get Exchange Offers."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Get Exchange Offers is not performed due to The To Token Address is not added."
+      );
+    }
+  });
+
+  // SWAP ON XDAI NETWORK WITH INVALID fromTokenAddress VALUE WHILE GET THE EXCHANGE OFFERS
+  it("Setup the SDK for xDai network and perform the single chain swap action with invalid fromTokenAddress value while get the exchange offers.", async () => {
+    // Initialize the SDK and define network
+    sdkTestNet = new Sdk(process.env.PRIVATE_KEY, {
+      env: EnvNames.TestNets,
+      networkName: NetworkNames.Xdai,
+    });
+
+    assert.strictEqual(
+      sdkTestNet.state.accountAddress,
+      "0xa5494Ed2eB09F37b4b0526a8e4789565c226C84f",
+      "The EOA Address is not displayed correctly."
+    );
+
+    // Compute the smart wallet address
+    const smartWalletOutput = await sdkTestNet.computeContractAccount();
+    smartWalletAddress = smartWalletOutput.address;
+    console.log("Smart wallet address: ", smartWalletAddress);
+
+    assert.strictEqual(
+      smartWalletAddress,
+      "0x666E17ad27fB620D7519477f3b33d809775d65Fe",
+      "The smart address is not displayed correctly."
+    );
+
+    // GET EXCHANGE OFFERS
+    try {
+      await sdkTestNet.getExchangeOffers({
+        fromTokenAddress: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A88", // USDC Token
+        toTokenAddress: "0x4ECaBa5870353805a9F068101A40E0f32ed605C6", // USDT Token
+        fromAmount: ethers.utils.parseUnits("0.0001", 6),
+      });
+      assert.isFalse(
+        "The Swap is performed, Even if the From Token Address is not added in the Get Exchange Offers."
+      );
+    } catch (e) {
+      console.log(
+        e,
+        "The Get Exchange Offers is not performed due to The From Token Address is not added."
+      );
+    }
+  });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Implemented below mentioned edge cases of the Single Chain Swap Flow for xDai Network:

- Verify the Single Chain Swap action from ERC20 token to ERC20 Token with exceeded the token balance on MainNet and TestNet. (Implemented for xDai network only)
- Verify the Single Chain Swap action from ERC20 token to Native Token with exceeded the token balance on MainNet and TestNet. (Implemented for xDai network only)
- Verify the Single Chain Swap action from the ERC20 token to the same ERC20 token on MainNet and TestNet. (Implemented for xDai network only)
- Verify the Single Chain Swap action without the toTokenAddress value while getting the exchange offers on MainNet and TestNet. (Implemented for xDai network only)
- Verify the Single Chain Swap action without the fromTokenAddress value while getting the exchange offers on MainNet and TestNet. (Implemented for xDai network only)
- Verify the Single Chain Swap action without the fromAmount value while getting the exchange offers on MainNet and TestNet. (Implemented for xDai network only)
- Verify the Single Chain Swap action with an invalid toTokenAddress value while getting the exchange offers on MainNet and TestNet. (Implemented for xDai network only)
- Verify the Single Chain Swap action with an invalid fromTokenAddress value while getting the exchange offers on MainNet and TestNet. (Implemented for xDai network only)